### PR TITLE
[kilted] Update deprecated call to ament_target_dependencies

### DIFF
--- a/aruco_markers/CMakeLists.txt
+++ b/aruco_markers/CMakeLists.txt
@@ -25,25 +25,23 @@ find_package(tf2_geometry_msgs REQUIRED)
 # Create the executable for the node
 add_executable(aruco_markers src/aruco_markers.cpp)
 
-# Link the OpenCV libraries to your node
-ament_target_dependencies(aruco_markers
-  rclcpp
-  std_msgs
-  OpenCV
-  image_transport
-  cv_bridge
-  tf2_ros
-  geometry_msgs
-  sensor_msgs
-  aruco_markers_msgs
-  tf2_geometry_msgs
-)
-
 # Include OpenCV headers
 target_include_directories(aruco_markers PRIVATE ${OpenCV_INCLUDE_DIRS})
 
 # Link OpenCV libraries to your node
-target_link_libraries(aruco_markers ${OpenCV_LIBRARIES})
+target_link_libraries(aruco_markers PUBLIC
+  ${OpenCV_LIBRARIES}
+  ${aruco_markers_msgs_TARGETS}
+  ${geometry_msgs_TARGETS}
+  ${sensor_msgs_TARGETS}
+  ${std_msgs_TARGETS}
+  cv_bridge::cv_bridge
+  image_transport::image_transport
+  rclcpp::rclcpp
+  sensor_msgs::sensor_msgs_library
+  tf2_geometry_msgs::tf2_geometry_msgs
+  tf2_ros::tf2_ros
+)
 
 
 # Install the executable

--- a/aruco_markers/CMakeLists.txt
+++ b/aruco_markers/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 add_executable(aruco_markers src/aruco_markers.cpp)
 
 # Link the OpenCV libraries to your node
-ament_target_dependencies(aruco_markers
+target_link_libraries(aruco_markers PUBLIC
   rclcpp
   std_msgs
   OpenCV

--- a/aruco_markers/CMakeLists.txt
+++ b/aruco_markers/CMakeLists.txt
@@ -26,7 +26,7 @@ find_package(tf2_geometry_msgs REQUIRED)
 add_executable(aruco_markers src/aruco_markers.cpp)
 
 # Link the OpenCV libraries to your node
-target_link_libraries(aruco_markers PUBLIC
+ament_target_dependencies(aruco_markers
   rclcpp
   std_msgs
   OpenCV


### PR DESCRIPTION
As of the ROS 2 Kilted release [`ament_target_dependencies` is deprecated.](https://docs.ros.org/en/kilted/Releases/Release-Kilted-Kaiju.html#ament-target-dependencies-is-deprecated)

This PR updates the syntax. Caution should be used to ensure that the target branch is not used for other ROS 2 distros.

Note: This PR was generated by a bot script, but using the simple pattern matching of the [`ros_glint`](https://github.com/MetroRobots/ros_glint) library. No LLMs were used.
